### PR TITLE
new: Update werkzeug to fix CVE-2025-66221 and CVE-2026-21860

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,5 @@ python-dateutil==2.8.2
 Flask==3.0.2
 argus-api-client==0.4.3
 gunicorn==23.0.0
+werkzeug==3.1.5
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -167,7 +167,9 @@ typing-extensions==4.13.2 \
     --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
     --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
     # via anyio
-werkzeug==3.1.3 \
-    --hash=sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e \
-    --hash=sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746
-    # via flask
+werkzeug==3.1.5 \
+    --hash=sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc \
+    --hash=sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67
+    # via
+    #   -r requirements.in
+    #   flask


### PR DESCRIPTION
This will clear the two pending Dependabot alerts.